### PR TITLE
Modify slippage dash order sizes

### DIFF
--- a/app.py
+++ b/app.py
@@ -80,7 +80,9 @@ def exchange_slippages():
         )
     """)
 
-    query = """
+    order_sizes = [1000, 10000, 25000, 50000, 100000, 500000]
+
+    db.executemany("""
         insert into quotes
         with
             orders as (
@@ -151,9 +153,7 @@ def exchange_slippages():
             weighted_average_buy_price,
             weighted_average_sell_price
         from weighted_average_fill_prices inner join misc using (exchange, symbol)
-    """
-
-    db.executemany(query, [[50000], [100000], [200000], [500000], [1000000]])
+    """, [[order_size] for order_size in order_sizes])
 
     data = db.execute("""
         with

--- a/templates/_exchange.html
+++ b/templates/_exchange.html
@@ -17,11 +17,12 @@
                   <table class="table table-borderless mb-0" style="border-color: #2A2440">
                       <thead style="border-bottom: 1px solid #2A2440; font-size: 12px ">
                           <th class="fw-bold py-3">Pair</th>
+                          <th class="fw-bold text-center py-3">$1K</th>
+                          <th class="fw-bold text-center py-3">$10K</th>
+                          <th class="fw-bold text-center py-3">$25K</th>
                           <th class="fw-bold text-center py-3">$50K</th>
                           <th class="fw-bold text-center py-3">$100K</th>
-                          <th class="fw-bold text-center py-3">$200K</th>
                           <th class="fw-bold text-center py-3">$500K</th>
-                          <th class="fw-bold text-center py-3">$1M</th>
                       </thead>
                       <tbody>
                       {% for symbol, spreads in executions %}


### PR DESCRIPTION
$200K and $1M sizes removed, added $10K and $25K.

Before:
<img width="1310" alt="Screen Shot 2022-06-08 at 15 24 07" src="https://user-images.githubusercontent.com/28162761/172655485-a39bda40-7c3a-44ba-ab99-fd6db4fbc4f1.png">

After:
<img width="1138" alt="Screen Shot 2022-06-08 at 15 23 47" src="https://user-images.githubusercontent.com/28162761/172655441-ed52c66b-bf19-4635-92b9-80c66532c6c6.png">